### PR TITLE
Fix abs and signum definitions for Bit n

### DIFF
--- a/Haskell/Blarney/Core/Bit.hs
+++ b/Haskell/Blarney/Core/Bit.hs
@@ -341,18 +341,13 @@ liftNat nat k =
 
 -- |Convert list of bits to bit vector
 fromBitList :: KnownNat n => [Bit 1] -> Bit n
-fromBitList [] = FromBV $ constBV 0 0
-fromBitList (x:xs)
-  | length (x:xs) == n = result
-  | otherwise =
-     error ("fromList: bit vector width mismatch: " ++ show (n, length (x:xs)))
+fromBitList xs
+  | length xs == n = result
+  | otherwise = error ("fromBitList: width mismatch: " ++
+                          show (length xs, n))
   where
-    n       = widthOf result
-    result  = FromBV (snd $ join (x:xs))
-    join [x] = (1, toBV x)
-    join (x:xs) =
-      let (n, y) = join xs in
-        (n+1, concatBV y (toBV x))
+    n = widthOf result
+    result = unsafeFromBitList xs
 
 -- |Convert bit vector to list of bits
 toBitList :: KnownNat n => Bit n -> [Bit 1]
@@ -372,6 +367,7 @@ unsafeToBitList bs = [unsafeAt i bs | i <- [0..size-1]]
 -- | Apply bit-list transformation on bit-vector
 onBitList :: ([Bit 1] -> [Bit 1]) -> Bit n -> Bit n
 onBitList f x
+  | null list = x
   | length list /= length list' =
       error "onBitList: transformation did not preserve length"
   | otherwise = unsafeFromBitList list'

--- a/Haskell/Blarney/Core/Prelude.hs
+++ b/Haskell/Blarney/Core/Prelude.hs
@@ -29,10 +29,6 @@ module Blarney.Core.Prelude
   , o               -- Function composition
   , (===)           -- Generic equality
   , (=!=)           -- Generic disequality
-  , sLT             -- Signed less than
-  , sGT             -- Signed greater than
-  , sLTE            -- Signed less than or equal
-  , sGTE            -- Signed greater than or equal
   , zero            -- Generic zero
   , ones            -- Generic all-ones
   , dontCare        -- Generic don't care
@@ -130,26 +126,6 @@ a === b = pack a .==. pack b
 infix 4 =!=
 (=!=) :: Bits a => a -> a -> Bit 1
 a =!= b = pack a .!=. pack b
-
--- |Signed less than
-infixl 8 `sLT`
-sLT :: (Bits a, SizeOf a ~ (1+n)) => a -> a -> Bit 1
-sLT x y = invMSB (pack x) .<. invMSB (pack y)
-
--- |Signed greater than
-infixl 8 `sGT`
-sGT :: (Bits a, SizeOf a ~ (1+n)) => a -> a -> Bit 1
-sGT x y = invMSB (pack x) .>. invMSB (pack y)
-
--- |Signed less than or equal
-infixl 8 `sLTE`
-sLTE :: (Bits a, SizeOf a ~ (1+n)) => a -> a -> Bit 1
-sLTE x y = invMSB (pack x) .<=. invMSB (pack y)
-
--- |Signed greater than or equal
-infixl 8 `sGTE`
-sGTE :: (Bits a, SizeOf a ~ (1+n)) => a -> a -> Bit 1
-sGTE x y = invMSB (pack x) .>=. invMSB (pack y)
 
 -- |All 0's
 zero :: forall a. Bits a => a


### PR DESCRIPTION
A few changes here:

  * abs and signum were defined using unsigned comparators rather than
    signed ones.

  * I think the signed comparators should be defined on Bit n, not
    general Bits.

  * For the abs and signum definitions to work, I needed to drop the
    numeric constraint on invMSB.  This lead to few improvements to
    bit-vector <-> bit-list conversion, including a nice new onBitList
    transformer function.